### PR TITLE
Fix queries with missing args

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3.7'
 services:
   postgres:
     image: "postgres:latest"
-    container_name: further-postgres
     hostname: postgres
     user: postgres
     restart: always

--- a/test/unit/delete.test.ts
+++ b/test/unit/delete.test.ts
@@ -43,6 +43,32 @@ describe("delete", () => {
     expect(await middleware(params, next)).toEqual({ id: 1, deleted: true });
   });
 
+  it("does not modify delete with no args", async () => {
+    const middleware = createSoftDeleteMiddleware({ models: { User: true } });
+
+    // @ts-expect-error - args are required
+    const params = createParams("User", "delete", undefined);
+    const next = jest.fn(() => Promise.resolve({}));
+
+    await middleware(params, next);
+
+    // params have not been modified
+    expect(next).toHaveBeenCalledWith(params);
+  });
+
+  it("does not modify delete with no where", async () => {
+    const middleware = createSoftDeleteMiddleware({ models: { User: true } });
+
+    // @ts-expect-error - where is required
+    const params = createParams("User", "delete", {});
+    const next = jest.fn(() => Promise.resolve({}));
+
+    await middleware(params, next);
+
+    // params have not been modified
+    expect(next).toHaveBeenCalledWith(params);
+  });
+
   it("changes delete action into an update to add deleted mark", async () => {
     const middleware = createSoftDeleteMiddleware({
       models: { User: true },

--- a/test/unit/deleteMany.test.ts
+++ b/test/unit/deleteMany.test.ts
@@ -64,6 +64,46 @@ describe("deleteMany", () => {
     });
   });
 
+  it("changes deleteMany action with no args into an updateMany that adds deleted mark", async () => {
+    const middleware = createSoftDeleteMiddleware({
+      models: { User: true },
+    });
+
+    const next = jest.fn(() => Promise.resolve({}));
+    const params = createParams("User", "deleteMany", undefined);
+    await middleware(params, next);
+
+    // params are modified correctly
+    expect(next).toHaveBeenCalledWith({
+      ...params,
+      action: "updateMany",
+      args: {
+        where: { deleted: false },
+        data: { deleted: true },
+      },
+    });
+  });
+
+  it("changes deleteMany action with no where into an updateMany that adds deleted mark", async () => {
+    const middleware = createSoftDeleteMiddleware({
+      models: { User: true },
+    });
+
+    const next = jest.fn(() => Promise.resolve({}));
+    const params = createParams("User", "deleteMany", {});
+    await middleware(params, next);
+
+    // params are modified correctly
+    expect(next).toHaveBeenCalledWith({
+      ...params,
+      action: "updateMany",
+      args: {
+        where: { deleted: false },
+        data: { deleted: true },
+      },
+    });
+  });
+
   it("changes nested deleteMany action into an updateMany that adds deleted mark", async () => {
     const middleware = createSoftDeleteMiddleware({
       models: { Post: true },

--- a/test/unit/findFirst.test.ts
+++ b/test/unit/findFirst.test.ts
@@ -46,6 +46,46 @@ describe("findFirst", () => {
     });
   });
 
+  it("excludes deleted records from findFirst with no args", async () => {
+    const middleware = createSoftDeleteMiddleware({ models: { User: true } });
+
+    const params = createParams("User", "findFirst", undefined);
+    const next = jest.fn(() => Promise.resolve({}));
+
+    await middleware(params, next);
+
+    // params have been modified
+    expect(next).toHaveBeenCalledWith({
+      ...params,
+      action: "findFirst",
+      args: {
+        where: {
+          deleted: false,
+        },
+      },
+    });
+  });
+
+  it("excludes deleted records from findFirst with empty args", async () => {
+    const middleware = createSoftDeleteMiddleware({ models: { User: true } });
+
+    const params = createParams("User", "findFirst", {});
+    const next = jest.fn(() => Promise.resolve({}));
+
+    await middleware(params, next);
+
+    // params have been modified
+    expect(next).toHaveBeenCalledWith({
+      ...params,
+      action: "findFirst",
+      args: {
+        where: {
+          deleted: false,
+        },
+      },
+    });
+  });
+
   it("allows explicitly querying for deleted records using findFirst", async () => {
     const middleware = createSoftDeleteMiddleware({
       models: { User: true },

--- a/test/unit/findMany.test.ts
+++ b/test/unit/findMany.test.ts
@@ -46,6 +46,50 @@ describe("findMany", () => {
     });
   });
 
+  it("excludes deleted records from findMany with no args", async () => {
+    const middleware = createSoftDeleteMiddleware({
+      models: { User: true },
+    });
+
+    const params = createParams("User", "findMany", undefined);
+    const next = jest.fn(() => Promise.resolve({}));
+
+    await middleware(params, next);
+
+    // params have been modified
+    expect(next).toHaveBeenCalledWith({
+      ...params,
+      action: "findMany",
+      args: {
+        where: {
+          deleted: false,
+        },
+      },
+    });
+  });
+
+  it("excludes deleted records from findMany with empty args", async () => {
+    const middleware = createSoftDeleteMiddleware({
+      models: { User: true },
+    });
+
+    const params = createParams("User", "findMany", {});
+    const next = jest.fn(() => Promise.resolve({}));
+
+    await middleware(params, next);
+
+    // params have been modified
+    expect(next).toHaveBeenCalledWith({
+      ...params,
+      action: "findMany",
+      args: {
+        where: {
+          deleted: false,
+        },
+      },
+    });
+  });
+
   it("allows explicitly querying for deleted records using findMany", async () => {
     const middleware = createSoftDeleteMiddleware({
       models: { User: true },

--- a/test/unit/findUnique.test.ts
+++ b/test/unit/findUnique.test.ts
@@ -45,4 +45,34 @@ describe("findUnique", () => {
       },
     });
   });
+
+  it("does not modify findUnique to be a findFirst when no args passed", async () => {
+    const middleware = createSoftDeleteMiddleware({
+      models: { User: true },
+    });
+
+    // @ts-expect-error testing if user doesn't pass args accidentally
+    const params = createParams("User", "findUnique", undefined);
+    const next = jest.fn(() => Promise.resolve({}));
+
+    await middleware(params, next);
+
+    // params have not been modified
+    expect(next).toHaveBeenCalledWith(params);
+  });
+
+  it("does not modify findUnique to be a findFirst when no where passed", async () => {
+    const middleware = createSoftDeleteMiddleware({
+      models: { User: true },
+    });
+
+    // @ts-expect-error testing if user doesn't pass where accidentally
+    const params = createParams("User", "findUnique", {});
+    const next = jest.fn(() => Promise.resolve({}));
+
+    await middleware(params, next);
+
+    // params have not been modified
+    expect(next).toHaveBeenCalledWith(params);
+  });
 });

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -56,7 +56,7 @@ describe("update", () => {
     const middleware = createSoftDeleteMiddleware({
       models: { User: true },
       defaultConfig: {
-        field: 'deleted',
+        field: "deleted",
         createValue: Boolean,
         allowToOneUpdates: true,
       },
@@ -100,6 +100,32 @@ describe("update", () => {
         },
       },
     });
+    const next = jest.fn(() => Promise.resolve({}));
+
+    await middleware(params, next);
+
+    // params have not been modified
+    expect(next).toHaveBeenCalledWith(params);
+  });
+
+  it("does not modify update when no args are passed", async () => {
+    const middleware = createSoftDeleteMiddleware({ models: { User: true } });
+
+    // @ts-expect-error - args are required
+    const params = createParams("User", "update", undefined);
+    const next = jest.fn(() => Promise.resolve({}));
+
+    await middleware(params, next);
+
+    // params have not been modified
+    expect(next).toHaveBeenCalledWith(params);
+  });
+
+  it("does not modify update when no where is passed", async () => {
+    const middleware = createSoftDeleteMiddleware({ models: { User: true } });
+
+    // @ts-expect-error - where is required
+    const params = createParams("User", "update", {});
     const next = jest.fn(() => Promise.resolve({}));
 
     await middleware(params, next);


### PR DESCRIPTION
closes #1 

Currently there are cases where it is assumed that the args object is
defined, and also the where object within. This is not always correct,
for example findMany can be used without args or a where.

Update action middleware to ensure operations that can being used
without args or a where object are supported.

Additionally, we are assuming the user is passing valid arguments all
the time, however there are cases where it would be better to allow
Prisma to throw an error rather than trying to modify the params.

Pass root delete operations with no where and updateMany operations
with no args through to Prisma to throw a useful error.