### PR TITLE
fix: findUnique with compound unique index where

### DIFF
--- a/src/lib/createSoftDeleteMiddleware.ts
+++ b/src/lib/createSoftDeleteMiddleware.ts
@@ -28,6 +28,7 @@ export function createSoftDeleteMiddleware({
     field: "deleted",
     createValue: Boolean,
     allowToOneUpdates: false,
+    allowCompoundUniqueIndexWhere: false,
   },
 }: Config) {
   if (!defaultConfig.field) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,7 @@ export type ModelConfig = {
   field: string;
   createValue: (deleted: boolean) => any;
   allowToOneUpdates?: boolean;
+  allowCompoundUniqueIndexWhere?: boolean;
 };
 
 export type Config = {


### PR DESCRIPTION
When using a findUnique query with a compound unique index field in the where object, such as "name_email" for the User model, the action is changed to findFirst which does not support that where field.

Throw when encountering compound unique index fields in the findUnique where object by default since using findUnique we cannot exclude soft deleted models. Add a "allowCompoundUniqueIndexWhere" field to the model config to allow users to override the default behaviour. When the default behaviour is overridden don't switch the action type to findFirst, but also don't exclude soft deleted models.

This is not a breaking change since all queries that currently use compound index where fields throw anyways, so throwing at that time does not cause a change in behaviour, only in the error message.