### PR TITLE
Add support for custom-defined createValue function

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,8 +52,9 @@ model Comment {
 }
 
 model Profile {
-  id      Int     @id @default(autoincrement())
-  bio     String?
-  deleted Boolean @default(false)
-  users   User[]
+  id        Int      @id @default(autoincrement())
+  bio       String?
+  deleted   Boolean  @default(false)
+  deletedAt DateTime @default(dbgenerated("to_timestamp(0)"))
+  users     User[]
 }

--- a/src/lib/utils/resultFiltering.ts
+++ b/src/lib/utils/resultFiltering.ts
@@ -1,4 +1,5 @@
 import { NestedParams } from "prisma-nested-middleware";
+import isEqual from "lodash/isEqual";
 
 import { ModelConfig } from "../types";
 
@@ -10,20 +11,20 @@ export function shouldFilterDeletedFromReadResult(
     !params.scope?.relations.to.isList &&
     (!params.args.where ||
       typeof params.args.where[config.field] === "undefined" ||
-      params.args.where[config.field] === config.createValue(false))
+      isEqual(params.args.where[config.field], config.createValue(false)))
   );
 }
 
 export function filterSoftDeletedResults(result: any, config: ModelConfig) {
   // filter out deleted records from array results
   if (result && Array.isArray(result)) {
-    return result.filter(
-      (item) => item[config.field] === config.createValue(false)
+    return result.filter((item) =>
+      isEqual(item[config.field], config.createValue(false))
     );
   }
 
   // if the result is deleted return null
-  if (result && result[config.field] !== config.createValue(false)) {
+  if (result && !isEqual(result[config.field], config.createValue(false))) {
     return null;
   }
 

--- a/src/lib/utils/resultFiltering.ts
+++ b/src/lib/utils/resultFiltering.ts
@@ -17,11 +17,13 @@ export function shouldFilterDeletedFromReadResult(
 export function filterSoftDeletedResults(result: any, config: ModelConfig) {
   // filter out deleted records from array results
   if (result && Array.isArray(result)) {
-    return result.filter((item) => !item[config.field]);
+    return result.filter(
+      (item) => item[config.field] === config.createValue(false)
+    );
   }
 
   // if the result is deleted return null
-  if (result && result[config.field]) {
+  if (result && result[config.field] !== config.createValue(false)) {
     return null;
   }
 

--- a/src/lib/utils/resultFiltering.ts
+++ b/src/lib/utils/resultFiltering.ts
@@ -10,7 +10,7 @@ export function shouldFilterDeletedFromReadResult(
   return (
     !params.args.where ||
     typeof params.args.where[config.field] === "undefined" ||
-    !params.args.where[config.field]
+    params.args.where[config.field] === config.createValue(false)
   );
 }
 

--- a/test/e2e/nestedReads.test.ts
+++ b/test/e2e/nestedReads.test.ts
@@ -11,7 +11,16 @@ describe("nested reads", () => {
   beforeAll(async () => {
     testClient = new PrismaClient();
     testClient.$use(
-      createSoftDeleteMiddleware({ models: { Comment: true, Profile: true } })
+      createSoftDeleteMiddleware({
+        models: {
+          Comment: true,
+          // use truthy value for non-deleted to test that they are still filtered
+          Profile: {
+            field: "deletedAt",
+            createValue: (deleted) => (deleted ? new Date() : new Date(0)),
+          },
+        },
+      })
     );
 
     user = await client.user.create({
@@ -66,7 +75,7 @@ describe("nested reads", () => {
     // restore soft deleted profile
     await client.profile.updateMany({
       where: {},
-      data: { deleted: false },
+      data: { deletedAt: new Date(0) },
     });
   });
   afterAll(async () => {
@@ -107,7 +116,7 @@ describe("nested reads", () => {
       await client.profile.updateMany({
         where: {},
         data: {
-          deleted: true,
+          deletedAt: new Date(),
         },
       });
 
@@ -214,7 +223,7 @@ describe("nested reads", () => {
       await client.profile.updateMany({
         where: {},
         data: {
-          deleted: true,
+          deletedAt: new Date(),
         },
       });
 
@@ -402,7 +411,7 @@ describe("nested reads", () => {
       await client.profile.update({
         where: { id: profile!.id },
         data: {
-          deleted: true,
+          deletedAt: new Date(),
         },
       });
 


### PR DESCRIPTION
### Proposal:
We made changes so the condition in `createValue` property that `the method must return a falsy value if the record is not deleted and vice versa` does not have to be forced. With the modification, we can define `createValue` functions that have a custom value for whether the record is soft deleted or not. For example, `new Date(0)` can be a value for a non-deleted record though it is truthy.

### Rationale:
We initially used `deletedAt: DateTime` as the field just like everyone else, with NULL representing a false value for being not deleted, and we were using Postgres as our underlying database. The problem arose with the following chain:

1. We used some fields along with `deletedAt` as a UNIQUE CONSTRAINT, but in Postgres, NULL values are not considered distinct, which could bring many potential data integrity problems for us. More details in this [post](https://dba.stackexchange.com/questions/9759/postgresql-multi-column-unique-constraint-and-null-values).
2. The post provided solutions like upgrading to version 15, and using a partial unique index, which one our cloud provider cannot guarantee, and the other Prisma doesn't support.
3. We thought about converting DateTime to number(TypeScript)/BIGINT(Postgres), and using `0: number` to represent the value not being soft deleted. But the issue was BIGINT cannot be saved in JSON format.
4. We converted DateTime to string, using `'0': string` as the default value for not being soft deleted, and stringfying the DateTime to represent a record has been soft deleted. 

### Implementation:
We only changed a few lines in `lib/utils/resultFiltering.ts` so now the rows are filtered on an exact equality check with the value defined in `createValue` function. Since `deletedAt` should really only contain two types of values -- one representing soft-deletedness, the other not being deleted, we believe an equality check is fine, as it is similar to what boolean is doing (one or the other). I also noted that `createValue(false)` was used extensively throughout the project so why discard checking equality with it during the filter stage?

We are not sure if our change still serves the original purpose of what the package was doing, so please point out if we made a mistake in the fork.

### Conclusion:
We really appreciate your work in opensourcing this soft-delete package, which Prisma doesn't support officially, and we believe you had your take and philosophy on designing the function to return only truthy/falsy values, as it's much simpler API defining what users can and should do. We propose this as an alternative to defining `createValue` in a truthy/falsy way, as defining in that way will still be supported under the current version.