### PR TITLE
Models are not being included on delete method.

### DIFF
--- a/src/lib/actionMiddleware.ts
+++ b/src/lib/actionMiddleware.ts
@@ -53,9 +53,21 @@ function createDeleteParams(
       ...params,
       action: "update",
       args: {
-        ...params.args,
         __passUpdateThrough: true,
         [field]: createValue(true),
+      },
+    };
+  }
+
+  if (!!params.scope) {
+    return {
+      ...params,
+      action: "update",
+      args: {
+        where: params.args,
+        data: {
+          [field]: createValue(true),
+        },
       },
     };
   }
@@ -65,7 +77,6 @@ function createDeleteParams(
     action: "update",
     args: {
       ...params.args,
-      where: params.args?.where || params.args,
       data: {
         [field]: createValue(true),
       },

--- a/src/lib/actionMiddleware.ts
+++ b/src/lib/actionMiddleware.ts
@@ -53,6 +53,7 @@ function createDeleteParams(
       ...params,
       action: "update",
       args: {
+        ...params.args,
         __passUpdateThrough: true,
         [field]: createValue(true),
       },
@@ -63,6 +64,7 @@ function createDeleteParams(
     ...params,
     action: "update",
     args: {
+      ...params.args,
       where: params.args?.where || params.args,
       data: {
         [field]: createValue(true),

--- a/test/unit/include.test.ts
+++ b/test/unit/include.test.ts
@@ -2,7 +2,7 @@ import { set } from "lodash";
 import faker from "faker";
 
 import { createSoftDeleteMiddleware } from "../../src";
-import { createParams } from "./utils/createParams";
+import { createParams, ActionByModel } from "./utils/createParams";
 
 describe("include", () => {
   it("does not change include params if model is not in the list", async () => {
@@ -20,6 +20,44 @@ describe("include", () => {
     // params have not been modified
     expect(next).toHaveBeenCalledWith(params);
   });
+
+  it.each([
+    "delete",
+    "update",
+    "upsert",
+    "findFirst",
+    "findFirstOrThrow",
+    "findUnique",
+    "findUniqueOrThrow",
+    "findMany",
+  ] as Array<ActionByModel<"User">>)(
+    "can include records for configured models in %s",
+    async (action) => {
+      const middleware = createSoftDeleteMiddleware({
+        models: { User: true },
+      });
+
+      const params = createParams("User", action, {
+        where: { id: 1 },
+        include: {
+          comments: true,
+        },
+      });
+
+      const next = jest.fn(() =>
+        Promise.resolve({
+          comments: [{ deleted: true }, { deleted: false }],
+        })
+      );
+
+      await middleware(params, next);
+
+      // @ts-expect-error - ts doesn't know there has been a call
+      expect(next.mock.calls[0][0]?.args?.include).toEqual({
+        comments: true,
+      });
+    }
+  );
 
   it("uses params to exclude deleted records from toMany includes", async () => {
     const middleware = createSoftDeleteMiddleware({
@@ -138,7 +176,7 @@ describe("include", () => {
     expect(next).toHaveBeenCalledWith(params);
     expect(result).toEqual({ author: null });
   });
-  
+
   it("does not manually exclude non-deleted records from toOne include with nested includes", async () => {
     const middleware = createSoftDeleteMiddleware({
       models: { User: true },
@@ -262,7 +300,6 @@ describe("include", () => {
       ],
     });
   });
-
 
   it("allows explicitly including deleted records using include", async () => {
     const middleware = createSoftDeleteMiddleware({

--- a/test/unit/utils/createParams.ts
+++ b/test/unit/utils/createParams.ts
@@ -30,7 +30,7 @@ type IncludeByModel<Model extends Prisma.ModelName> = Model extends "User"
   ? Prisma.CommentInclude
   : never;
 
-type ActionByModel<Model extends Prisma.ModelName> =
+export type ActionByModel<Model extends Prisma.ModelName> =
   | keyof DelegateByModel<Model>
   | "connectOrCreate"
   | "select"


### PR DESCRIPTION
### Description
When you try to execute delete method with "include" param, function createDeleteParams doesn't consider it.

### Query
```typescript
 const res = await prisma.key.delete({
    where: {
      id: 6
    },
    include: {
      game: true,
      manager: true,
    },
  });
```

#### Actual query results
``` typescript
{
  id: 6,
  managerId: 3,
  gameId: 10,
  deletedAt: 2023-12-27T01:57:28.486Z
}
```

#### Expected query results
``` typescript
{
  id: 6,
  managerId: 3,
  gameId: 10,
  deletedAt: 2023-12-27T01:58:15.158Z,
  game: { ... },
  manager: {
    ...
  }
}
```
### Solution
It can be fixed easily by adding ```...params.args``` to returning params object in createDeleteParams. Or you may explicitly pass ```params.args.include``` so be sure unconsidered data won't be in params.


### Environment
Prisma-soft-delete-middleware version: 1.1.2
Prisma version: 5.2.0
Node.js version: 18.12.1