### PR TITLE
perf: filter toMany select relations with where

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Olivier Wilkinson",
   "license": "Apache-2.0",
   "dependencies": {
-    "prisma-nested-middleware": "^3.0.3"
+    "prisma-nested-middleware": "^4.0.0"
   },
   "peerDependencies": {
     "@prisma/client": "*"

--- a/src/lib/actionMiddleware.ts
+++ b/src/lib/actionMiddleware.ts
@@ -566,11 +566,6 @@ function createSelectParams(
   params: NestedParams,
   config: ModelConfig
 ): NestedParams {
-  // selects in includes are handled by createIncludeParams
-  if (params.scope?.parentParams.action === "include") {
-    return params;
-  }
-
   // selects of toOne relation cannot filter deleted records using params
   if (params.scope?.relations?.to.isList === false) {
     if (params.args?.select && !params.args.select[config.field]) {

--- a/src/lib/utils/resultFiltering.ts
+++ b/src/lib/utils/resultFiltering.ts
@@ -2,15 +2,15 @@ import { NestedParams } from "prisma-nested-middleware";
 
 import { ModelConfig } from "../types";
 
-// Maybe this should return true for non-list relations only?
 export function shouldFilterDeletedFromReadResult(
   params: NestedParams,
   config: ModelConfig
 ): boolean {
   return (
-    !params.args.where ||
-    typeof params.args.where[config.field] === "undefined" ||
-    !params.args.where[config.field]
+    !params.scope?.relations.to.isList &&
+    (!params.args.where ||
+      typeof params.args.where[config.field] === "undefined" ||
+      params.args.where[config.field] === config.createValue(false))
   );
 }
 

--- a/test/e2e/nestedReads.test.ts
+++ b/test/e2e/nestedReads.test.ts
@@ -230,7 +230,7 @@ describe("nested reads", () => {
       expect(softDeletedProfile).toBeNull();
     });
 
-    it("excludes deleted when deeply including relations", async () => {
+    it("excludes deleted when deeply selecting relations", async () => {
       const {
         comments: nonDeletedComments,
       } = await testClient.user.findUniqueOrThrow({

--- a/test/unit/include.test.ts
+++ b/test/unit/include.test.ts
@@ -175,56 +175,6 @@ describe("include", () => {
     });
   });
 
-  it("excludes deleted records from toMany include nested in toMany include", async () => {
-    const middleware = createSoftDeleteMiddleware({
-      models: { Comment: true },
-    });
-
-    const params = createParams("User", "findFirst", {
-      where: { id: 1 },
-      include: {
-        posts: {
-          include: {
-            comments: true,
-          },
-        },
-      },
-    });
-
-    const next = jest.fn(() =>
-      Promise.resolve({
-        posts: [
-          {
-            comments: [{ deleted: true }, { deleted: false }],
-          },
-          {
-            comments: [
-              { deleted: false },
-              { deleted: false },
-              { deleted: true },
-            ],
-          },
-        ],
-      })
-    );
-
-    const result = await middleware(params, next);
-
-    expect(next).toHaveBeenCalledWith(
-      set(params, "args.include.posts.include.comments", {
-        where: {
-          deleted: false,
-        },
-      })
-    );
-    expect(result).toEqual({
-      posts: [
-        { comments: [{ deleted: false }] },
-        { comments: [{ deleted: false }, { deleted: false }] },
-      ],
-    });
-  });
-
   it("manually excludes deleted records from toOne include nested in toMany include", async () => {
     const middleware = createSoftDeleteMiddleware({
       models: { User: true },


### PR DESCRIPTION
Rather than filtering results when selecting a toMany relation ensure that the relation is filtered using a modified where object in the query.

This was previously difficult due to the nature of the select action: it was impossible to distinguish between an include.select and a relational select action.

Upgrading to v4 of prisma-nested-middleware removes the include.select variant of the select action, allowing this library to remove the logic that deferred select actions within an include to the parent action. That logic that deferred to the parent also prevented always modifying the select action to use the where strategy.